### PR TITLE
Minor typo in ubuntu container image name

### DIFF
--- a/responses/07_add-windows.md
+++ b/responses/07_add-windows.md
@@ -8,7 +8,7 @@ Since we'd like to support deploying our app to Windows environments, let's add 
 You can follow the suggestion, or manually make the changes in the numbered instructions.
 
 ```suggestion
-        os: [ubuntu-lastest, windows-2016]
+        os: [ubuntu-latest, windows-2016]
         node-version: [8.x, 10.x]
 ```
 

--- a/responses/08_new-job.md
+++ b/responses/08_new-job.md
@@ -41,7 +41,7 @@ Let's now try to create a dedicated test job. This will allow us to separate the
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          os: [ubuntu-lastest, windows-2016]
+          os: [ubuntu-latest, windows-2016]
           node-version: [8.x, 10.x]
       steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
When following the course, the suggestions in response 7&8 have a minor typo in the ubuntu container image name.