### PR TITLE
Fix the typo in ubuntu-latest

### DIFF
--- a/responses/08_new-job.md
+++ b/responses/08_new-job.md
@@ -82,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-lastest, windows-2016]
+        os: [ubuntu-latest, windows-2016]
         node-version: [8.x, 10.x]
 
     steps:


### PR DESCRIPTION
👋 This PR fixes a little typo:

```diff
- ubuntu-lastest
+ ubuntu-latest
```