### PR TITLE
Add images and update node versions to 12.x and 14.x

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -21,7 +21,7 @@ before:
     store:
       first_issue_url: "{{ result.data.html_url }}"
 
-# Repository artifacts
+# Repository artifacts:
 # 1. Issue: There's a bug!
 # 2. PR: CI for Node (learner)
 # 3. PR: Add jest tests (bot)

--- a/responses/00_bug.md
+++ b/responses/00_bug.md
@@ -4,6 +4,10 @@ In this repository, we'll be diving into the world of Continuous Integration. **
 
 ### What is CI? Why should you care?
 
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/6351798/88584678-3e81c400-d00f-11ea-95e0-01d8708c6e84.png">
+</p>
+
 [CI](https://en.wikipedia.org/wiki/Continuous_integration) can help you stick to your team’s quality standards by running tests and reporting the results on GitHub. CI tools run builds and tests, triggered by commits. The results post back to GitHub in the pull request. This reduces context switching for developers, and improves consistency for testing. The goal is fewer bugs in production and faster feedback while developing.
 
 Choices around CI that will work best for your project depend on many factors, including:
@@ -22,6 +26,8 @@ In other courses, you may have noticed that some actions take me longer to respo
 If you aren't already familiar, it may be a good idea to go through the [Introduction to GitHub Learning Lab](https://lab.github.com/githubtraining/introduction-to-github).
 
 ## Step 1: Use a templated workflow
+
+<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88585528-6f162d80-d010-11ea-8efa-1e6d6d8bcb99.png">
 
 There's a bug somewhere in this repository. We'll use the practice of Continuous Integration (CI) to set up some automated testing to make it easier to discover, diagnose, and minimize scenarios like this.
 

--- a/responses/00_bug.md
+++ b/responses/00_bug.md
@@ -5,7 +5,7 @@ In this repository, we'll be diving into the world of Continuous Integration. **
 ### What is CI? Why should you care?
 
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/6351798/88584678-3e81c400-d00f-11ea-95e0-01d8708c6e84.png">
+  <img alt="a gear and a loop, representing continuous integration" src="https://user-images.githubusercontent.com/6351798/88584678-3e81c400-d00f-11ea-95e0-01d8708c6e84.png">
 </p>
 
 [CI](https://en.wikipedia.org/wiki/Continuous_integration) can help you stick to your team’s quality standards by running tests and reporting the results on GitHub. CI tools run builds and tests, triggered by commits. The results post back to GitHub in the pull request. This reduces context switching for developers, and improves consistency for testing. The goal is fewer bugs in production and faster feedback while developing.
@@ -27,7 +27,7 @@ If you aren't already familiar, it may be a good idea to go through the [Introdu
 
 ## Step 1: Use a templated workflow
 
-<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88585528-6f162d80-d010-11ea-8efa-1e6d6d8bcb99.png">
+<img alt="icon of a bug in a browser window" align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88585528-6f162d80-d010-11ea-8efa-1e6d6d8bcb99.png">
 
 There's a bug somewhere in this repository. We'll use the practice of Continuous Integration (CI) to set up some automated testing to make it easier to discover, diagnose, and minimize scenarios like this.
 

--- a/responses/01_explain-checkout.md
+++ b/responses/01_explain-checkout.md
@@ -2,12 +2,14 @@
 
 #### Workflows, steps, actions, and jobs
 
+![workflow](https://user-images.githubusercontent.com/6351798/88589835-f5ce0900-d016-11ea-8c8a-0e7d7907c713.png)
+
 Let's dig into the vocabulary of GitHub Actions.
 
 - **Workflow**: A workflow is a unit of automation from start to finish, including the definition of what triggers the automation, what environment or other aspects should be taken account during the automation, and what should happen as a result of the trigger.
+- **Job**: A job is a section of the workflow, and is made up of one or more steps. In this section of our workflow, the template defines the steps that make up the `build` job.
 - **Step**: A step represents one _effect_ of the automation. A step could be defined as a GitHub Action, or another unit, like printing something to the console.
 - **Action**: A GitHub Action is a piece of automation written in a way that is compatible with workflows. Actions can be written by GitHub, by the open source community, or you can write them yourself!
-- **Job**: A job is a section of the workflow, and is made up of one or more steps. In this section of our workflow, the template defines the steps that make up the `build` job.
 
 #### What is `checkout`?
 

--- a/responses/01_explain-checkout.md
+++ b/responses/01_explain-checkout.md
@@ -2,7 +2,7 @@
 
 #### Workflows, steps, actions, and jobs
 
-![workflow](https://user-images.githubusercontent.com/6351798/88589835-f5ce0900-d016-11ea-8c8a-0e7d7907c713.png)
+![An illustration split in two. On the left: illustration of how GitHub Actions terms are encapsulated. At the highest level: workflows and event triggers. Inside of workflows: jobs and definition of the build environment. Inside jobs: steps. Inside steps: a call to an action. On the right: the sequence: workflows, job, step, action.](https://user-images.githubusercontent.com/6351798/88589835-f5ce0900-d016-11ea-8c8a-0e7d7907c713.png)
 
 Let's dig into the vocabulary of GitHub Actions.
 

--- a/responses/06_custom-workflow.md
+++ b/responses/06_custom-workflow.md
@@ -4,13 +4,7 @@ Now that we've learned how to quickly set up CI, let's try a more realistic use 
 
 Our fictional team has a custom workflow that goes beyond the template we've used so far. We would like the following features:
 
-- **test against multiple targets** so that we know if our supported operating systems and Node.js versions are working
-- **dedicated test job** so that we can separate out build from test details
-- **access to build artifacts** so that we can deploy them to a target environment
-- **branch protections** so that the `master` branch can't be deleted or inadvertently broken
-- **required reviews** so that any pull requests are double checked by teammates
-- **obvious approvals** so we can merge quickly and potentially automate merges and deployments
-
+![custom-workflow-list](https://user-images.githubusercontent.com/6351798/88590869-a8eb3200-d018-11ea-9967-6ca4fbdf831d.png)
 
 ## Step 7: Create a custom GitHub Actions workflow
 

--- a/responses/06_custom-workflow.md
+++ b/responses/06_custom-workflow.md
@@ -7,7 +7,7 @@ Our fictional team has a custom workflow that goes beyond the template we've use
 <img alt="an icon of three gears" align="left" width="50" height="50" src="https://user-images.githubusercontent.com/6351798/88609410-48241f80-d041-11ea-85ad-b77a5d08bfd1.png"><br/>
 **Test against multiple targets** so that we know if our supported operating systems and Node.js versions are working
 
-<img alt="icon of gears indicating relatiopnship between multiple jobs" align="left" width="50" height="50" src="https://user-images.githubusercontent.com/6351798/88609439-55410e80-d041-11ea-8186-09b2008e2572.png"><br/>
+<img alt="icon of gears indicating relationship between multiple jobs" align="left" width="50" height="50" src="https://user-images.githubusercontent.com/6351798/88609439-55410e80-d041-11ea-8186-09b2008e2572.png"><br/>
 **Dedicated test job** so that we can separate out build from test details
 
 <img alt="icon of a binary file" align="left" width="50" height="50" src="https://user-images.githubusercontent.com/6351798/88609455-5ffba380-d041-11ea-9e29-c2bac7a8dfd4.png"><br/>
@@ -29,7 +29,7 @@ Can GitHub Actions support this workflow? Let's find out. We'll tackle some of t
 ### :keyboard: Activity: Edit the existing workflow with new build targets
 
 1. Edit your [existing workflow]({{ workflowUrl }}) file in a new branch
-2. In that file, target versions `8.x` and `10.x` of Node, only
+2. In that file, target versions `12.x` and `14.x` of Node, only
 3. Open a new pull request titled **Improve CI** for your change.
 
 I'll respond when you open the pull request.

--- a/responses/06_custom-workflow.md
+++ b/responses/06_custom-workflow.md
@@ -4,7 +4,23 @@ Now that we've learned how to quickly set up CI, let's try a more realistic use 
 
 Our fictional team has a custom workflow that goes beyond the template we've used so far. We would like the following features:
 
-![custom-workflow-list](https://user-images.githubusercontent.com/6351798/88590869-a8eb3200-d018-11ea-9967-6ca4fbdf831d.png)
+<img alt="an icon of three gears" align="left" width="50" height="50" src="https://user-images.githubusercontent.com/6351798/88609410-48241f80-d041-11ea-85ad-b77a5d08bfd1.png"><br/>
+**Test against multiple targets** so that we know if our supported operating systems and Node.js versions are working
+
+<img alt="icon of gears indicating relatiopnship between multiple jobs" align="left" width="50" height="50" src="https://user-images.githubusercontent.com/6351798/88609439-55410e80-d041-11ea-8186-09b2008e2572.png"><br/>
+**Dedicated test job** so that we can separate out build from test details
+
+<img alt="icon of a binary file" align="left" width="50" height="50" src="https://user-images.githubusercontent.com/6351798/88609455-5ffba380-d041-11ea-9e29-c2bac7a8dfd4.png"><br/>
+**Access to build artifacts** so that we can deploy them to a target environment
+
+<img alt="icon of a security shield indicating branch protections" align="left" width="50" height="50" src="https://user-images.githubusercontent.com/6351798/88609465-6a1da200-d041-11ea-9c4c-55ffe90a3e72.png"><br/>
+**Branch protections** so that the `master` branch can't be deleted or inadvertently broken
+
+<img alt="icon of a review approval" align="left" width="50" height="50" src="https://user-images.githubusercontent.com/6351798/88609558-9df8c780-d041-11ea-906f-dd23efd9f65c.png"><br/>
+**Required reviews** so that any pull requests are double checked by teammates
+
+<img alt="icon of a review approval" align="left" width="50" height="50" src="https://user-images.githubusercontent.com/6351798/88609481-73a70a00-d041-11ea-959d-27b33c2d4028.png"><br/>
+**Obvious approvals** so we can merge quickly and potentially automate merges and deployments
 
 ## Step 7: Create a custom GitHub Actions workflow
 

--- a/responses/07_add-windows.md
+++ b/responses/07_add-windows.md
@@ -1,7 +1,7 @@
 
 ## Step 8: Target a Windows environment
 
-Since we'd like to support deploying our app to Windows environments, let's add Windows to the matrix build configuration. 
+Since we'd like to support deploying our app to Windows environments, let's add Windows to the matrix build configuration.
 
 ### :keyboard: Activity: Edit your workflow file to build for Windows environments
 
@@ -11,7 +11,7 @@ You can follow the suggestion, or manually make the changes in the numbered inst
 
 ```suggestion
         os: [ubuntu-latest, windows-2016]
-        node-version: [8.x, 10.x]
+        node-version: [12.x, 14.x]
 ```
 
 1. Edit the workflow config at [`.github/workflows/nodejs.yml`]({{ fileUrl }})

--- a/responses/07_add-windows.md
+++ b/responses/07_add-windows.md
@@ -5,7 +5,7 @@ Since we'd like to support deploying our app to Windows environments, let's add 
 
 ### :keyboard: Activity: Edit your workflow file to build for Windows environments
 
-<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88591917-5ca0f180-d01a-11ea-8ed2-219aa3392cf2.png">
+<img alt="an icon of three gears" align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88591917-5ca0f180-d01a-11ea-8ed2-219aa3392cf2.png">
 
 You can follow the suggestion, or manually make the changes in the numbered instructions.
 

--- a/responses/07_add-windows.md
+++ b/responses/07_add-windows.md
@@ -5,6 +5,8 @@ Since we'd like to support deploying our app to Windows environments, let's add 
 
 ### :keyboard: Activity: Edit your workflow file to build for Windows environments
 
+<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88591917-5ca0f180-d01a-11ea-8ed2-219aa3392cf2.png">
+
 You can follow the suggestion, or manually make the changes in the numbered instructions.
 
 ```suggestion

--- a/responses/08_new-job.md
+++ b/responses/08_new-job.md
@@ -7,7 +7,11 @@ Our custom workflow now accounts for:
 
 ## Step 9: Use multiple jobs
 
-Let's now try to create a dedicated test job. This will allow us to separate the build and test functions of our workflow.
+<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592093-aab5f500-d01a-11ea-8631-b2200684e7e0.png">
+
+Let's now try to create a dedicated test job and satisfy the second item in our custom workflow checklist. 
+
+This will allow us to separate the build and test functions of our workflow into more than one job that will run when our workflow is triggered.
 
 ### Activity: Edit your workflow file to separate build and test jobs
 

--- a/responses/08_new-job.md
+++ b/responses/08_new-job.md
@@ -7,7 +7,7 @@ Our custom workflow now accounts for:
 
 ## Step 9: Use multiple jobs
 
-<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592093-aab5f500-d01a-11ea-8631-b2200684e7e0.png">
+<img alt="icon of gears indicating relatiopnship between multiple jobs" align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592093-aab5f500-d01a-11ea-8631-b2200684e7e0.png">
 
 Let's now try to create a dedicated test job and satisfy the second item in our custom workflow checklist. 
 

--- a/responses/08_new-job.md
+++ b/responses/08_new-job.md
@@ -7,7 +7,7 @@ Our custom workflow now accounts for:
 
 ## Step 9: Use multiple jobs
 
-<img alt="icon of gears indicating relatiopnship between multiple jobs" align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592093-aab5f500-d01a-11ea-8631-b2200684e7e0.png">
+<img alt="icon of gears indicating relationship between multiple jobs" align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592093-aab5f500-d01a-11ea-8631-b2200684e7e0.png">
 
 Let's now try to create a dedicated test job and satisfy the second item in our custom workflow checklist. 
 
@@ -46,7 +46,7 @@ This will allow us to separate the build and test functions of our workflow into
       strategy:
         matrix:
           os: [ubuntu-latest, windows-2016]
-          node-version: [8.x, 10.x]
+          node-version: [12.x, 14.x]
       steps:
       - uses: actions/checkout@v2
       - name: Use Node.js {% raw %}${{ matrix.node-version }}{% endraw %}
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-2016]
-        node-version: [8.x, 10.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -110,7 +110,7 @@ When you commit to this branch, the workflow should run again. I'll respond when
 
 <details><summary>Actions workflow not running? Click here</summary>
 
-When a GitHub Actions workflow is running, you should see some checks in progress, like the screenshot below. 
+When a GitHub Actions workflow is running, you should see some checks in progress, like the screenshot below.
 
 ![checks in progress in a merge box](https://user-images.githubusercontent.com/16547949/66080348-ecc5f580-e533-11e9-909e-c213b08790eb.png)
 

--- a/responses/10_use-upload.md
+++ b/responses/10_use-upload.md
@@ -4,11 +4,15 @@ The workflow has finished running!
 
 You may notice `build` succeeded, but each of the `test` jobs failed. That's because the build artifacts created in `build` aren't available to the `test` job. Each job executes in a fresh instance of the virtual environment. This is due to the [design of the virtual environments](https://help.github.com/en/articles/virtual-environments-for-github-actions#about-virtual-environments) themselves.
 
-So what do we do when we need the work product of one job in another? We can use the built-in [artifact storage](https://help.github.com/en/articles/persisting-workflow-data-using-artifacts).
+So what do we do when we need the work product of one job in another? We can use the built-in [artifact storage](https://help.github.com/en/articles/persisting-workflow-data-using-artifacts) to save artifacts created from one job to be used in another job within the same workflow. 
 
 ## Step 11: Upload a job's build artifacts
 
-First, we'll need to save the artifacts created from `build`. We can use an action built by GitHub to do this: [`actions/upload-artifacts`](https://github.com/actions/upload-artifact).
+<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592731-b2c26480-d01b-11ea-850e-c87588aadf4f.png">
+
+Artifacts allow you to persist data after a job has completed, and share that data with another job in the same workflow. An artifact is a file or collection of files produced during a workflow run.
+
+To upload artifacts to the artifact storage, we can use an action built by GitHub: [`actions/upload-artifacts`](https://github.com/actions/upload-artifact).
 
 ### :keyboard: Activity: Use the upload action in your workflow file to save a job's build artifacts
 

--- a/responses/10_use-upload.md
+++ b/responses/10_use-upload.md
@@ -8,7 +8,7 @@ So what do we do when we need the work product of one job in another? We can use
 
 ## Step 11: Upload a job's build artifacts
 
-<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592731-b2c26480-d01b-11ea-850e-c87588aadf4f.png">
+<img alt="icon of a binary file" align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592731-b2c26480-d01b-11ea-850e-c87588aadf4f.png">
 
 Artifacts allow you to persist data after a job has completed, and share that data with another job in the same workflow. An artifact is a file or collection of files produced during a workflow run.
 

--- a/responses/11_use-download.md
+++ b/responses/11_use-download.md
@@ -8,7 +8,9 @@ Great! The build artifacts will now be uploaded to the artifact storage. If you 
 
 <img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592731-b2c26480-d01b-11ea-850e-c87588aadf4f.png">
 
-To remedy this, we'll run `test` only after `build` is finished so the artifacts are available. Similar to the upload action to send artifacts to the storage, we'll use another action built by GitHub to download these previously uploaded artifacts from the `build` job: [`actions/download-artifact`](https://github.com/actions/download-artifact).
+To remedy this, we'll run `test` only after `build` is finished so the artifacts are available. 
+
+Similar to the upload action to send artifacts to the storage, we'll use another action built by GitHub to download these previously uploaded artifacts from the `build` job: [`actions/download-artifact`](https://github.com/actions/download-artifact).
 
 ### :keyboard: Activity: Use the download action in your workflow file to access a prior job's build artifacts
 

--- a/responses/11_use-download.md
+++ b/responses/11_use-download.md
@@ -6,7 +6,7 @@ Great! The build artifacts will now be uploaded to the artifact storage. If you 
 
 ## Step 12: Download a job's build artifacts
 
-<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592731-b2c26480-d01b-11ea-850e-c87588aadf4f.png">
+<img alt="icon of a binary file" align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592731-b2c26480-d01b-11ea-850e-c87588aadf4f.png">
 
 To remedy this, we'll run `test` only after `build` is finished so the artifacts are available. 
 

--- a/responses/11_use-download.md
+++ b/responses/11_use-download.md
@@ -6,7 +6,9 @@ Great! The build artifacts will now be uploaded to the artifact storage. If you 
 
 ## Step 12: Download a job's build artifacts
 
-To remedy this, we'll run `test` only after `build` is finished so the artifacts are available, and we'll use another action built by GitHub, [`actions/download-artifact`](https://github.com/actions/download-artifact) to retrieve artifacts from the `build` job.
+<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88592731-b2c26480-d01b-11ea-850e-c87588aadf4f.png">
+
+To remedy this, we'll run `test` only after `build` is finished so the artifacts are available. Similar to the upload action to send artifacts to the storage, we'll use another action built by GitHub to download these previously uploaded artifacts from the `build` job: [`actions/download-artifact`](https://github.com/actions/download-artifact).
 
 ### :keyboard: Activity: Use the download action in your workflow file to access a prior job's build artifacts
 

--- a/responses/16_add-step.md
+++ b/responses/16_add-step.md
@@ -13,9 +13,7 @@ Let's see if you can use this action on your own.
 
 **If you'd like a hint, submit a comment on this pull request with the word "hint".**
 
-<br/>
-
-Here's some tips to get you going:
+### Here's some tips to get you going:
 - the workflow file needs a `steps:` block
 - give your new step any name you wish
 - to use a community action, use the `uses:` keyword

--- a/responses/16_add-step.md
+++ b/responses/16_add-step.md
@@ -7,7 +7,7 @@ It's now time to use a community-created action. The action we'll use is [pullre
 
 ## Step 17: Automate approvals
 
-<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88593701-2fa20e00-d01d-11ea-85df-d620868a5f0d.png">
+<img alt="icon of a review approval" align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88593701-2fa20e00-d01d-11ea-85df-d620868a5f0d.png">
 
 Let's see if you can use this action on your own. 
 

--- a/responses/16_add-step.md
+++ b/responses/16_add-step.md
@@ -7,7 +7,13 @@ It's now time to use a community-created action. The action we'll use is [pullre
 
 ## Step 17: Automate approvals
 
-Let's see if you can use this action on your own. **If you'd like a hint, submit a comment on this pull request with the word "hint".**
+<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88593701-2fa20e00-d01d-11ea-85df-d620868a5f0d.png">
+
+Let's see if you can use this action on your own. 
+
+**If you'd like a hint, submit a comment on this pull request with the word "hint".**
+
+<br/>
 
 Here's some tips to get you going:
 - the workflow file needs a `steps:` block

--- a/responses/16_add-step.md
+++ b/responses/16_add-step.md
@@ -12,6 +12,7 @@ It's now time to use a community-created action. The action we'll use is [pullre
 Let's see if you can use this action on your own. 
 
 **If you'd like a hint, submit a comment on this pull request with the word "hint".**
+<br/><br/>
 
 ### Here's some tips to get you going:
 - the workflow file needs a `steps:` block

--- a/responses/17_protect-master.md
+++ b/responses/17_protect-master.md
@@ -15,7 +15,7 @@ Take a look at the merge box, you'll notice you can merge this even though the r
 
 ## Step 18: Use branch protections
 
-<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88594106-ddadb800-d01d-11ea-9ec9-fca55c0c69e2.png">
+<img alt="icon of a security shield indicating branch protections" align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88594106-ddadb800-d01d-11ea-9ec9-fca55c0c69e2.png">
 
 Protected branches ensure that collaborators on your repository cannot make irrevocable changes to branches. Enabling protected branches also allows you to enable other optional checks and requirements, like required status checks and required reviews.
 

--- a/responses/17_protect-master.md
+++ b/responses/17_protect-master.md
@@ -15,6 +15,10 @@ Take a look at the merge box, you'll notice you can merge this even though the r
 
 ## Step 18: Use branch protections
 
+<img align="left" width="100" height="100" src="https://user-images.githubusercontent.com/6351798/88594106-ddadb800-d01d-11ea-9ec9-fca55c0c69e2.png">
+
+Protected branches ensure that collaborators on your repository cannot make irrevocable changes to branches. Enabling protected branches also allows you to enable other optional checks and requirements, like required status checks and required reviews.
+
 Next, add branch protections and continue with the course.
 
 ### :keyboard: Activity: Complete the automated review process by protecting the master branch


### PR DESCRIPTION
This resolves https://github.com/githubtraining/using-github-actions-for-ci/issues/17 by adding some images images to the response files.

<details>
<summary>Images</summary>
<br>

![CI](https://user-images.githubusercontent.com/6351798/88594426-66c4ef00-d01e-11ea-8ddd-a05e1850b801.png)
![fix](https://user-images.githubusercontent.com/6351798/88594428-688eb280-d01e-11ea-91f2-529303f2c4d3.png)
![workflow](https://user-images.githubusercontent.com/6351798/88594450-704e5700-d01e-11ea-9411-c921693011d9.png)
![custom-workflow-list](https://user-images.githubusercontent.com/6351798/88594454-717f8400-d01e-11ea-929a-e49cb96fd941.png)
</details>

This also fixes https://github.com/githubtraining/using-github-actions-for-ci/issues/44by updating the node versions from 8.x and 10.x to 12.x and 14.x. 

@githubtraining/programs 
