### PR TITLE
fix label-when-approved-action branch

### DIFF
--- a/responses/17_add-step-suggestion.md
+++ b/responses/17_add-step-suggestion.md
@@ -6,7 +6,7 @@
         runs-on: ubuntu-latest
         steps:
         - name: Label when approved
-          uses: pullreminders/label-when-approved-action@main
+          uses: pullreminders/label-when-approved-action@master
           env:
             APPROVALS: "1"
             GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}


### PR DESCRIPTION
[pullreminders/label-when-approved-action](https://github.com/abinoda/label-when-approved-action) repo has only master branch, resulting in a build failure now.