### PR TITLE
Add contains test to list of failing tests

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -137,7 +137,7 @@ steps:
     link: "{{ store.second_pr_url }}"
     actions:
       - type: gate
-        left: "/(Initializes with two players)|(Starts the game with a random player)|(Sets the current player to be whoever it is not)/gim"
+        left: "/(Contains the compiled JavaScript)|(Initializes with two players)|(Starts the game with a random player)|(Sets the current player to be whoever it is not)/gim"
         operator: test
         right: "%payload.comment.body%"
         required: false

--- a/responses/e-test-name.md
+++ b/responses/e-test-name.md
@@ -1,6 +1,7 @@
 That wasn't the test name I expected, but that's alright. If you typed something slightly different than what I looked for that may explain it. 
 
 I expected one of the following test names:
+- Contains the compiled JavaScript
 - Initializes with two players
 - Starts the game with a random player
 - Sets the current player to be whoever it is not


### PR DESCRIPTION
Step 3 Missing 'Contains the compiled JavaScript' test in list of failing tests #59 